### PR TITLE
Specify C# 7.3 because recent C# features are used in GPOGroupTasks.cs

### DIFF
--- a/SharpHound3/SharpHound3.csproj
+++ b/SharpHound3/SharpHound3.csproj
@@ -42,6 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -51,6 +52,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>favicon.ico</ApplicationIcon>


### PR DESCRIPTION
Otherwise the default is to use the "latest major version of C#" which I guess is 7.0 (on my VS 2017)
By setting it explicitly it works