### PR TITLE
Fixes missing type for member of Groups in GPO Templates

### DIFF
--- a/SharpHound3/Tasks/GPOGroupTasks.cs
+++ b/SharpHound3/Tasks/GPOGroupTasks.cs
@@ -416,8 +416,14 @@ namespace SharpHound3.Tasks
 
                                     type = lType;
                                 }
+                                else
+                                {
+                                    var (aSid, lType) = await ResolutionHelpers.ResolveSidAndGetType(sid, gpoDomain);
+                                    sid = aSid;
+                                    type = lType;
+                                }
 
-                                if (sid == null || !sid.StartsWith("S-1-5", StringComparison.OrdinalIgnoreCase))
+                                if (sid == null)
                                     continue;
 
                                 // Loop over matches and add the actions appropriately


### PR DESCRIPTION
The LDAP type of members of a group (e.g. `LocalAdmins`) in a GPO Template is not resolved if the group is set with its SID.

Excerpt of ous.json before PR:
```
{"Properties":{... ,"LocalAdmins":[{"MemberId":"S-1-5-21-1941773369-757073348-2584032387-1132","MemberType":"Unknown"}], ...}
```

Excerpt of ous.json after PR:
```
{"Properties":{... ,"LocalAdmins":[{"MemberId":"S-1-5-21-1941773369-757073348-2584032387-1132","MemberType":"Group"}], ...}
```