### PR TITLE
Hardening of password protected zip files

### DIFF
--- a/SharpHound3/Tasks/OutputTasks.cs
+++ b/SharpHound3/Tasks/OutputTasks.cs
@@ -355,7 +355,7 @@ namespace SharpHound3.Tasks
             const string space = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
             var builder = new StringBuilder();
             var random = new Random();
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < 20; i++)
             {
                 builder.Append(space[random.Next(space.Length)]);
             }


### PR DESCRIPTION
10 characters passwords are thought to be copy-pasted in the same way as 20 character ones. Since the usage is only relevant as an export function it implies no change in terms of user experience (simply, copy-pasting) but introduces significant obstacles to potential brute-force attackers.