### PR TITLE
Add AddSelf ACE to Collection

### DIFF
--- a/SharpHound3/Tasks/ACLTasks.cs
+++ b/SharpHound3/Tasks/ACLTasks.cs
@@ -310,6 +310,25 @@ namespace SharpHound3.Tasks
                     }
                 }
 
+                if (rights.HasFlag(ActiveDirectoryRights.Self))
+                { 
+                    if (wrapper is Group)
+                    {
+                        if (objectAceType == "bf9679c0-0de6-11d0-a285-00aa003049e2")
+                        {
+                            aces.Add(new ACL
+                            {
+                                AceType = "AddSelf",
+                                RightName = "WriteProperty",
+                                PrincipalSID = finalSid,
+                                PrincipalType = type,
+                                IsInherited = isInherited
+                            }) ;
+                        }
+                    }
+
+                }
+
                 //PropertyWrites apply to Groups, User, Computer, GPO
                 //GenericWrite encapsulates WriteProperty, so we need to check them at the same time to avoid duplicate edges
                 if (rights.HasFlag(ActiveDirectoryRights.GenericWrite) ||


### PR DESCRIPTION
Adds the necessary logic to collect the "Add/Remove Self as Member" ACE as seen in [1]. This additional ACE collection means that we can add the "AddSelf" edge to the GUI when a principle has the ability to add themselves (but no one else) to a group. This information is not currently collected.
   
This PR is submitted in tandem with ? on the Bloodhound GUI side of things.
   
[1]: https://docs.microsoft.com/en-us/windows/win32/adschema/r-self-membership