### PR TITLE
Add NoZip parameter to powershell template

### DIFF
--- a/SharpHound3/PowerShell Output/Template.ps1
+++ b/SharpHound3/PowerShell Output/Template.ps1
@@ -260,6 +260,9 @@
         $EncryptZip,
 
 		[Switch]
+        $NoZip,
+
+		[Switch]
         $InvalidateCache,
 
         [String]


### PR DESCRIPTION
Fixes https://github.com/BloodHoundAD/BloodHound/issues/369

The parameter is handled in the code, but it is never received by the function itself!