### PR TITLE
Add new well-known SIDs S-1-5-113 and S-1-5-114

### DIFF
--- a/SharpHound3/CommonPrincipal.cs
+++ b/SharpHound3/CommonPrincipal.cs
@@ -136,6 +136,12 @@ namespace SharpHound3
                 case "S-1-5-20":
                     commonPrincipal = new CommonPrincipal("NT Authority", User);
                     break;
+                case "S-1-5-113":
+                    commonPrincipal = new CommonPrincipal("Local Account", User);
+                    break;
+                case "S-1-5-114":
+                    commonPrincipal = new CommonPrincipal("Local Account and Member of Administrators Group", User);
+                    break;
                 case "S-1-5-80-0":
                     commonPrincipal = new CommonPrincipal("All Services ", Group);
                     break;


### PR DESCRIPTION
Introduced by KB 2871997
https://support.microsoft.com/en-us/help/4488256/how-to-block-remote-use-of-local-accounts-in-windows
Can be seen when remotely collecting local administrators, or RDP users

I think (did not test) it is enough to prevent this:
![image](https://user-images.githubusercontent.com/550823/95620699-e2a4d400-0a70-11eb-856a-e06d9bd673e5.png)
:)