### PR TITLE
Fix SidToDomainNameCache

### DIFF
--- a/SharpHound3/ResolutionHelpers.cs
+++ b/SharpHound3/ResolutionHelpers.cs
@@ -479,9 +479,9 @@ namespace SharpHound3
                 if (SidToDomainNameCache.TryGetValue(domainSid, out var domainName))
                     return domainName;
 
-                var domain = await GetDomainNameFromSidLdap(sid);
+                var domain = await GetDomainNameFromSidLdap(domainSid);
 
-                SidToDomainNameCache.TryAdd(sid, domain);
+                SidToDomainNameCache.TryAdd(domainSid, domain);
                 return domain;
             }
             catch


### PR DESCRIPTION
The `SidToDomainNameCache` cache stores the association: domain SID without RID `domainSid` -> domain name. So it must be queried by domain SID (without RID). Moreover, the domain SID must be queried from AD without the RID part.

I discovered the issue when I saw (in TcpView) that many global connections were opened so I thought I should implement a GC connection pool (like the LDAP pool) but actually the issue was different and it kept trying to resolve the same domain SID!

Performance on a test domain: before 2m54s / after 2m30s. The performance difference is not significant between both though... Maybe on a larger domain. But I can clearly see much fewer GC connections

The code was introduced by d93c453708941457930758446b290f63c86c2b9e