### PR TITLE
Added exception handling for BestGuessConvert

### DIFF
--- a/SharpHound3/Tasks/ObjectPropertyTasks.cs
+++ b/SharpHound3/Tasks/ObjectPropertyTasks.cs
@@ -142,8 +142,18 @@ namespace SharpHound3.Tasks
             //A string ending with 0Z is likely a timestamp
             if (property.EndsWith("0Z"))
             {
-                var dt = DateTime.ParseExact(property, "yyyyMMddHHmmss.0K", CultureInfo.CurrentCulture);
-                return (long)dt.Subtract(WindowsEpoch).TotalSeconds;
+                // If the string isn't actually a timestamp, a System.FormatException will be thrown
+                try
+                {
+
+                    var dt = DateTime.ParseExact(property, "yyyyMMddHHmmss.0K", CultureInfo.CurrentCulture);
+                    return (long)dt.Subtract(WindowsEpoch).TotalSeconds;
+                }
+                catch
+                {
+                    // Not a valid timestamp
+                    return property;
+                }
             }
 
             //This string corresponds to the max int, and is usually set in accountexpires


### PR DESCRIPTION
Added exception handling for a System.FormatException that occurs when a property looks like a timestamp (ends with 0Z) but isn't actually a timestamp

This is fixed via a try catch to handle the uncaught exception, and a comment to explain what's actually going on :)

The following exception occurs under very specific AD configurations:

```
Unhandled Exception: System.AggregateException: One or more errors occurred. ---> System.AggregateException: One or more errors occurred. ---> System.AggregateException: One or more errors occurred. ---> System.AggregateException: One or more errors occurred. ---> System.FormatException: String was not recognized as a valid DateTime.
   at System.DateTimeParse.ParseExact(String s, String format, DateTimeFormatInfo dtfi, DateTimeStyles style)
   at System.DateTime.ParseExact(String s, String format, IFormatProvider provider)
   at SharpHound3.Tasks.ObjectPropertyTasks.BestGuessConvert(String property)
   at SharpHound3.Tasks.ObjectPropertyTasks.ParseAllProperties(LdapWrapper wrapper)
   at SharpHound3.Tasks.ObjectPropertyTasks.<ResolveObjectProperties>d__2.MoveNext()
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at SharpHound3.SharpHound.<Main>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at SharpHound3.SharpHound.<Main>(String[] args)
```