### PR TITLE
Added the raw UAC flag to the users JSON

### DIFF
--- a/SharpHound3/Tasks/ObjectPropertyTasks.cs
+++ b/SharpHound3/Tasks/ObjectPropertyTasks.cs
@@ -351,6 +351,10 @@ namespace SharpHound3.Tasks
                 passwdNotReq = (uacFlags & UacFlags.PasswordNotRequired) != 0;
                 unconstrained = (uacFlags & UacFlags.TrustedForDelegation) != 0;
                 pwdNeverExires = (uacFlags & UacFlags.DontExpirePassword) != 0;
+
+                // Adding the raw UAC flags for extensibility
+                // Can be used in queries via the apoc.bitwise.op functions
+                wrapper.Properties.Add("uac", baseFlags);
             }
 
             wrapper.Properties.Add("dontreqpreauth", dontReqPreAuth);


### PR DESCRIPTION
Added the raw value for the UAC flag in the user's object for extensibility (The field is called "uac" and value si the integer value to keep it more compact in the final JSON dataset).

This has a few benefits:

Allows blue team to identify potentially problematic accounts using the Bloodhound datasets by running queries like:
  - `match (u) where apoc.bitwise.op(u.uac, "&", 2097152) = 1 return u.name` matches all accounts with DES enabled
  - `match (u) where apoc.bitwise.op(u.uac, "&", 128) = 1 return u.name` matches all account with passwords stored using reversible encryption

Individual properties could be added for those elements (just like the "Enabled" property that is derived from this flag), but this approach allows for future elements of the UAC flag to be taken into consideration without having to make changes to Sharphound.

It also allows red team to identify accounts using DES (with the query listed above) to avoid potential downgrade detection usecases.